### PR TITLE
Disable GitHub Actions for iOS, tvOS, and watchOS

### DIFF
--- a/.github/workflows/VerifyChanges.yaml
+++ b/.github/workflows/VerifyChanges.yaml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Select Xcode 16.4
+      - name: Select Xcode 26.0.0
         run: |
-          sudo xcode-select -s /Applications/Xcode_16.4.0.app
+          sudo xcode-select -s /Applications/Xcode_26.0.0.app
       - name: Lint
         run: |
           Scripts/lint
@@ -28,12 +28,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: iOS
-            xcode_destination: "platform=iOS Simulator,name=iPhone SE (3rd generation)"
+#           - platform: iOS
+#             xcode_destination: "platform=iOS Simulator,name=iPhone SE (3rd generation)"
           - platform: macOS
             xcode_destination: "platform=macOS,arch=arm64"
-          - platform: tvOS
-            xcode_destination: "platform=tvOS Simulator,name=Apple TV 4K (3rd generation) (at 1080p)"
+#           - platform: tvOS
+#             xcode_destination: "platform=tvOS Simulator,name=Apple TV 4K (3rd generation) (at 1080p)"
     env:
       DEV_BUILDS: DevBuilds/Sources
       OTHER_XCODE_FLAGS: ${{ matrix.other_xcode_flags }}
@@ -68,9 +68,9 @@ jobs:
           sourcepackages-directory: .build/DerivedData/SourcePackages
           swiftpm-package-resolved-file: Package.resolved
           verbose: true
-      - name: Select Xcode 16.4
+      - name: Select Xcode 26.0
         run: |
-          sudo xcode-select -s /Applications/Xcode_16.4.0.app
+          sudo xcode-select -s /Applications/Xcode_26.0.0.app
       - name: Build for Testing
         run: |
           "$DEV_BUILDS"/build_and_test.sh --action build-for-testing
@@ -116,9 +116,9 @@ jobs:
       - name: Download xccovPretty output
         uses: actions/download-artifact@v4
         with:
-          name: xccovPrettyOutput-iOS
+          name: xccovPrettyOutput-macOS
       - name: Post Code Coverage Comment
         uses: thollander/actions-comment-pull-request@v3
         with:
-          file-path: xccovPretty-iOS.output
-          comment-tag: codeCoverage-iOS
+          file-path: xccovPretty-macOS.output
+          comment-tag: codeCoverage-macOS

--- a/.swift-format
+++ b/.swift-format
@@ -14,6 +14,7 @@
     "lineBreakBetweenDeclarationAttributes": false,
     "lineLength": 120,
     "maximumBlankLines": 2,
+    "multilineTrailingCommaBehavior": "alwaysUsed",
     "multiElementCollectionTrailingCommas": true,
     "noAssignmentInExpressions": {
         "allowedFunctions": []

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ View our [changelog](CHANGELOG.md) to see what’s new.
 
 ## Development Requirements
 
-DevColorExtraction requires a Swift 6.1 toolchain to build. We only test on Apple platforms. We follow
+DevColorExtraction requires a Swift 6.2+ toolchain to build. We only test on Apple platforms. We follow
 the [Swift API Design Guidelines][SwiftAPIDesignGuidelines]. We take pride in the fact that our
 public interfaces are fully documented and tested. We aim for overall test coverage over 97%.
 
@@ -42,9 +42,24 @@ public interfaces are fully documented and tested. We aim for overall test cover
 
 To set up the development environment:
 
-  1. Run `Scripts/install-git-hooks` to install pre-commit hooks that automatically check code
-    formatting.
+  1. Run `Scripts/install-git-hooks` to install git hooks that automatically check code
+     formatting on commits and run comprehensive tests before pushing.
   2. Use `Scripts/lint` to manually check code formatting at any time.
+  3. Use `Scripts/test-all-platforms` to run tests on all supported platforms locally.
+
+
+## Continuous Integration
+
+DevColorExtraction uses GitHub Actions for continuous integration. The CI pipeline:
+
+  - **Linting**: Automatically checks code formatting on all pull requests using `swift format`
+  - **Testing**: Runs tests on macOS (iOS and tvOS testing are disabled in CI due to reliability
+    issues)
+  - **Coverage**: Generates code coverage reports using xccovPretty
+
+For comprehensive cross-platform testing, developers should run `Scripts/test-all-platforms`
+locally or rely on the pre-push git hook which automatically runs all platform tests before
+pushing changes.
 
 
 ## Bugs and Feature Requests

--- a/Scripts/install-git-hooks
+++ b/Scripts/install-git-hooks
@@ -43,8 +43,41 @@ EOF
     echo "Pre-commit hook installed successfully!"
 }
 
+# Function to install the pre-push hook
+install_pre_push_hook() {
+    local pre_push_hook="$REPO_ROOT/.git/hooks/pre-push"
+
+    echo "Installing pre-push hook..."
+
+    cat > "$pre_push_hook" << 'EOF'
+#!/bin/bash
+
+# Get the directory where this hook is located
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Go to the repository root (two levels up from .git/hooks)
+REPO_ROOT="$(dirname "$(dirname "$HOOK_DIR")")"
+
+# Run the test-all-platforms script
+echo "Running tests on all platforms..."
+if ! "$REPO_ROOT/Scripts/test-all-platforms"; then
+    echo "Platform tests failed. Please fix issues before pushing."
+    exit 1
+fi
+
+echo "All platform tests passed."
+EOF
+
+    chmod +x "$pre_push_hook"
+    echo "Pre-push hook installed successfully!"
+}
+
 # Install the pre-commit hook
 install_pre_commit_hook
 
+# Install the pre-push hook
+install_pre_push_hook
+
 echo "All git hooks installed successfully!"
 echo "The pre-commit hook will run 'Scripts/lint' before each commit."
+echo "The pre-push hook will run 'Scripts/test-all-platforms' before each push."

--- a/Scripts/test-all-platforms
+++ b/Scripts/test-all-platforms
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${YELLOW}[$(date +'%H:%M:%S')] $1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+# Platforms to test
+PLATFORMS=(
+    "iOS Simulator,name=iPhone 16 Pro"
+    "macOS"
+    "tvOS Simulator,name=Apple TV 4K"
+)
+
+SCHEME="DevColorExtraction"
+FAILED_PLATFORMS=()
+
+print_status "Starting tests on all platforms..."
+echo
+
+for platform in "${PLATFORMS[@]}"; do
+    platform_name=$(echo "$platform" | cut -d',' -f1)
+    print_status "Testing on $platform_name..."
+
+    if xcodebuild test -scheme "$SCHEME" -destination "platform=$platform"; then
+        print_success "$platform_name tests passed"
+    else
+        print_error "$platform_name tests failed"
+        FAILED_PLATFORMS+=("$platform_name")
+    fi
+    echo
+done
+
+# Summary
+echo "=========================="
+if [ ${#FAILED_PLATFORMS[@]} -eq 0 ]; then
+    print_success "All platform tests passed!"
+    exit 0
+else
+    print_error "Tests failed on: ${FAILED_PLATFORMS[*]}"
+    exit 1
+fi


### PR DESCRIPTION
  - Due to the poor reliability of GitHub Actions, we are disabling PR checks
    for iOS and tvOS.
  - We’ve added Scripts/test-all-platforms, which runs tests against iOS, macOS,
    and tvOS.
  - We’ve updated install-git-hooks to install test-all-actions as a pre-push
    hook
